### PR TITLE
ENH: Add property as a supported type.

### DIFF
--- a/interface/tests/test_interface.py
+++ b/interface/tests/test_interface.py
@@ -386,3 +386,65 @@ def test_class_method():
           - foo: 'function' is not a subtype of expected type 'classmethod'"""
     )
     assert expected == str(e.value)
+
+
+def test_property():
+
+    class I(Interface):
+        @property
+        def foo(self):  # pragma: nocover
+            pass
+
+    class my_property(property):
+        pass
+
+    class Impl(implements(I)):
+        @my_property
+        def foo(self):  # pragma: nocover
+            pass
+
+    with pytest.raises(IncompleteImplementation) as e:
+        class Impl(implements(I)):
+            def foo(self):  # pragma: nocover
+                pass
+
+    expected = dedent(
+        """
+        class Impl failed to implement interface I:
+
+        The following methods of I were implemented with incorrect types:
+          - foo: 'function' is not a subtype of expected type 'property'"""
+    )
+    assert expected == str(e.value)
+
+    with pytest.raises(IncompleteImplementation) as e:
+        class Impl(implements(I)):
+            @property
+            def foo(self, a, b):  # pragma: nocover
+                pass
+
+    expected = dedent(
+        """
+        class Impl failed to implement interface I:
+
+        The following methods of I were implemented with invalid signatures:
+          - foo(self, a, b) != foo(self)"""
+    )
+    assert expected == str(e.value)
+
+    with pytest.raises(IncompleteImplementation) as e:
+        class Impl(implements(I)):
+            def foo(self, a, b):  # pragma: nocover
+                pass
+
+    expected = dedent(
+        """
+        class Impl failed to implement interface I:
+
+        The following methods of I were implemented with incorrect types:
+          - foo: 'function' is not a subtype of expected type 'property'
+
+        The following methods of I were implemented with invalid signatures:
+          - foo(self, a, b) != foo(self)"""
+    )
+    assert expected == str(e.value)

--- a/interface/typed_signature.py
+++ b/interface/typed_signature.py
@@ -20,6 +20,8 @@ class TypedSignature(object):
         self._type = type(obj)
         if isinstance(obj, (classmethod, staticmethod)):
             self._signature = signature(obj.__func__)
+        elif isinstance(obj, property):
+            self._signature = signature(obj.fget)
         else:
             self._signature = signature(obj)
 


### PR DESCRIPTION
Enables definitions such as:

```
class FooInterface(Interface):

    @property
    def bar(self):
        pass

class Foo(implements(FooInterface)):

    @property
    def bar(self):
        return 'baz'
```

If the implementation is missing the `property` decorator, such as:

```
class FooInterface(Interface):

    @property
    def bar(self):
        pass

class Foo(implements(FooInterface)):

    def bar(self):
        return 'baz'
```

Then an error is raised showing that the method has the wrong type:

```
The following methods of FooInterface were implemented with incorrect types:
  - bar: 'function' is not a subtype of expected type 'property'
```