### PR TITLE
ENH: Add Interface.from_class.

### DIFF
--- a/interface/interface.py
+++ b/interface/interface.py
@@ -298,7 +298,7 @@ class Interface(with_metaclass(InterfaceMeta)):
         return InterfaceMeta(
             name,
             (Interface,),
-            {name: getattr(existing_class, name) for name in subset},
+            {name: static_get_type_attr(existing_class, name) for name in subset},
         )
 
 


### PR DESCRIPTION
Adds a new classmethod, `from_class` to `Interface`, for generating an
interface from an existing class. This is useful when you want to create
a class whose interface matches the interface of an existing class you
can't control (e.g., for creating a test double of class defined in a
library).