### PR TITLE
BUG: Fix superclass checking for subclass methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ develop-eggs
 .installed.cfg
 coverage.xml
 nosetests.xml
+venv/
+.idea/
 
 # C Extensions
 *.o

--- a/interface/functional.py
+++ b/interface/functional.py
@@ -53,7 +53,7 @@ def merge(dicts):
     if len(dicts) == 0:
         return {}
     elif len(dicts) == 1:
-        return dicts[0]
+        return dicts[0].copy()
     else:
         out = dicts[0].copy()
         for other in dicts[1:]:

--- a/interface/tests/test_interface.py
+++ b/interface/tests/test_interface.py
@@ -901,8 +901,8 @@ def test_interface_subclass():
         def method_b(self):
             pass
 
+    # expected to fail since it's missing method_b
     with pytest.raises(InvalidImplementation) as exc:
-
         class JustA(implements(AandB)):  # pragma: nocover
             def method_a(self):
                 pass
@@ -917,8 +917,8 @@ def test_interface_subclass():
     )
     assert actual_message == expected_message
 
+    # expected to fail since it's missing method_a
     with pytest.raises(InvalidImplementation) as exc:
-
         class JustB(implements(AandB)):  # pragma: nocover
             def method_b(self):
                 pass
@@ -933,6 +933,12 @@ def test_interface_subclass():
     )
     assert actual_message == expected_message
 
+    # expected to pass since interface A only requires method_a
+    class JustA2(implements(A)):  # pragma: nocover
+        def method_a(self):
+            pass
+
+    # expected to pass since it implements both methods
     class Both(implements(AandB)):  # pragma: nocover
         def method_a(self):
             pass
@@ -950,8 +956,8 @@ def test_subclass_conflict_with_different_parents():
         def method_b(self):
             pass
 
+    # expected to fail since method_a has different signature in interface A
     with pytest.raises(TypeError) as exc:
-
         class C1(A):  # pragma: nocover
             def method_a(self, x):
                 pass
@@ -964,9 +970,9 @@ def test_subclass_conflict_with_different_parents():
     )
     assert actual_message == expected_message
 
+    # expected to fail since method_b has different signature in interface B
     with pytest.raises(TypeError) as exc:
-
-        class C2(A):  # pragma: nocover
+        class C2(B):  # pragma: nocover
             def method_b(self, y, z=None):
                 pass
 
@@ -977,6 +983,11 @@ def test_subclass_conflict_with_different_parents():
           - method_b(self, y, z=None) != method_b(self)"""
     )
     assert actual_message == expected_message
+
+    # expected to pass since method_b does not exist in interface A
+    class C3(A):  # pragma: nocover
+        def method_b(self, y, z=None):
+            pass
 
 
 def test_subclass_allow_compatible_extension():

--- a/interface/tests/test_utils.py
+++ b/interface/tests/test_utils.py
@@ -25,7 +25,11 @@ def test_wrap_and_unwrap():
 
 def test_merge():
     assert merge([]) == {}
-    assert merge([{"a": 1, "b": 2}]) == {"a": 1, "b": 2}
+
+    input = {"a": 1, "b": 2}
+    output = merge([input])
+    assert output is not input
+    assert output == input
 
     result = merge([{"a": 1}, {"b": 2}, {"a": 3, "c": 4}])
     assert result == {"a": 3, "b": 2, "c": 4}

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def install_requires():
 
 setup(
     name="python-interface",
-    version="1.6.0",
+    version="1.6.1",
     description="Pythonic Interface definitions",
     author="Scott Sanderson",
     author_email="scott.b.sanderson90@gmail.com",


### PR DESCRIPTION
When an interface is inherited, the classes that implement the parent interface are being checked for methods required by the child interface.

Example
```
from interface import Interface, implements

class Foo(Interface):
  def foo(self, a: str) -> str:
    pass

class Bar(Foo):
  def bar(self, b: str) -> str:
    pass

class Far(implements(Foo)):
  def foo(self, a: str) -> str:
    return a

far = Far()
far.foo("a")
```

When I run the above code, I get the following error
```
interface.interface.InvalidImplementation:
class Far failed to implement interface Foo:

The following methods of Foo were not implemented:
  - bar(self, b: str) -> str
```

The fix is to make a copy of the parent's `signature` in the `merge` function.